### PR TITLE
setLevel upgrade and allow channels to be disabled - updated

### DIFF
--- a/Shelly-RGBW-White.groovy
+++ b/Shelly-RGBW-White.groovy
@@ -21,6 +21,9 @@
  *-------------------------------------------------------------------------------------------------------------------
  *
  * See all the Shelly Products at https://shelly.cloud/
+ *  1.0.1 - Added chXEnabled for each channel (defaults to true for all changgels).
+            Calling on, off, or setLevel only affects the channels that are enabled
+          - Added override for setLevel to add a duration parameter used by Groups & Scenes.  duration is ignored.
  *  1.0.0 - Initial release
  *
  */
@@ -32,7 +35,7 @@ import groovy.json.*
 //	==========================================================
 
 def setVersion(){
-	state.Version = "1.0.0"
+	state.Version = "1.0.1"
 	state.InternalName = "ShellyRGBWhite"
 }
 
@@ -62,6 +65,7 @@ metadata {
         command "CH1Off"
         command "CH2Off"
         command "CH3Off"
+        command "setLevel0", ["Level"]
         command "setLevel1", ["Level"]
         command "setLevel2", ["Level"]
         command "setLevel3", ["Level"]

--- a/Shelly-RGBW-White.groovy
+++ b/Shelly-RGBW-White.groovy
@@ -21,8 +21,8 @@
  *-------------------------------------------------------------------------------------------------------------------
  *
  * See all the Shelly Products at https://shelly.cloud/
- *  1.0.1 - Added chXEnabled for each channel (defaults to true for all changgels).
-            Calling on, off, or setLevel only affects the channels that are enabled
+ *  1.0.1 - Added chXEnabled for each channel (defaults to true for all channels).
+            Calling on, off, or setLevel only affects the channels that are enabled.
           - Added override for setLevel to add a duration parameter used by Groups & Scenes.  duration is ignored.
  *  1.0.0 - Initial release
  *

--- a/Shelly-RGBW-White.groovy
+++ b/Shelly-RGBW-White.groovy
@@ -21,7 +21,8 @@
  *-------------------------------------------------------------------------------------------------------------------
  *
  * See all the Shelly Products at https://shelly.cloud/
- *  1.0.1 - Added chXEnabled for each channel (defaults to true for all channels).
+ *  1.0.1 - By exhumare
+          - Added chXEnabled for each channel (defaults to true for all channels).
             Calling on, off, or setLevel only affects the channels that are enabled.
           - Added override for setLevel to add a duration parameter used by Groups & Scenes.  duration is ignored.
  *  1.0.0 - Initial release

--- a/Shelly-RGBW-White.groovy
+++ b/Shelly-RGBW-White.groovy
@@ -492,6 +492,11 @@ def CH3Off() {
 }
 
 //switch.level
+def setLevel(percent, duration) {
+    // some automations make the call with a duration
+    setLevel(percent)
+}
+
 def setLevel(percent) {
     if (txtEnable) log.info "Executing setLevel"
     if (ch0Enabled) setLevel0(percent)

--- a/Shelly-RGBW-White.groovy
+++ b/Shelly-RGBW-White.groovy
@@ -128,6 +128,11 @@ metadata {
 	input name: "debugParse", type: "bool", title: "Enable JSON parse logging?", defaultValue: true
 	input name: "txtEnable", type: "bool", title: "Enable descriptionText logging", defaultValue: true
 	input name: "Shellyinfo", type: "text", title: "<center><font color=blue>Info Box</font><br>Shelly API docs located</center>", description: "<center><a href='http://shelly-api-docs.shelly.cloud/' target='_blank'>[here]</a></center>"
+    
+	input name: "ch0Enabled", type: "bool", title: "Channel 0 enabled?", defaultValue: true
+	input name: "ch1Enabled", type: "bool", title: "Channel 1 enabled?", defaultValue: true
+	input name: "ch2Enabled", type: "bool", title: "Channel 2 enabled?", defaultValue: true
+	input name: "ch3Enabled", type: "bool", title: "Channel 3 enabled?", defaultValue: true
 	}
 }
 
@@ -437,10 +442,10 @@ try {
 //switch.on
 def on() {
     if (txtEnable) log.info "Executing switch.on"
-    sendSwitchCommand "/white/0?turn=on"
-    sendSwitchCommand "/white/1?turn=on"
-    sendSwitchCommand "/white/2?turn=on"
-    sendSwitchCommand "/white/3?turn=on"
+    if (ch0Enabled) CH0On()
+    if (ch1Enabled) CH1On()
+    if (ch2Enabled) CH2On()
+    if (ch3Enabled) CH3On()
 }
 
 def CH0On() {
@@ -463,10 +468,10 @@ def CH3On() {
 //switch.off
 def off() {
     if (txtEnable) log.info "Executing switch.off"
-    sendSwitchCommand "/white/0?turn=off"
-    sendSwitchCommand "/white/1?turn=off"
-    sendSwitchCommand "/white/2?turn=off"
-    sendSwitchCommand "/white/3?turn=off"
+    if (ch0Enabled) CH0Off()
+    if (ch1Enabled) CH1Off()
+    if (ch2Enabled) CH2Off()
+    if (ch3Enabled) CH3Off()
 }
 
 def CH0Off() {
@@ -488,6 +493,14 @@ def CH3Off() {
 
 //switch.level
 def setLevel(percent) {
+    if (txtEnable) log.info "Executing setLevel"
+    if (ch0Enabled) setLevel0(percent)
+    if (ch1Enabled) setLevel1(percent)
+    if (ch2Enabled) setLevel2(percent)
+    if (ch3Enabled) setLevel3(percent)
+}
+
+def setLevel0(percent) {
     sendSwitchCommand "/white/0?turn=on&brightness=${percent}"
 }
 


### PR DESCRIPTION
- Added chXEnabled for each channel (defaults to true for all channels).
  Calling on, off, or setLevel only affects the channels that are enabled.
- Added override for setLevel to add a duration parameter used by Groups & Scenes.  duration is ignored.