### PR TITLE
battery percentage

### DIFF
--- a/PLUS/Shelly-Plus-ht.groovy
+++ b/PLUS/Shelly-Plus-ht.groovy
@@ -90,7 +90,7 @@ def parse(String description) {
   if (topic == "${settings?.topicSub}/status/devicepower:0") {
       def pr_vals = parser.parseText(payload)
 
-      sendEvent(name: "battery", value: pr_vals['battery'], displayed: true)
+      sendEvent(name: "battery", value: pr_vals['battery']['percent'], displayed: true)
   }
   if (topic == "${settings?.topicSub}/status/wifi") {
       def pr_vals = parser.parseText(payload)


### PR DESCRIPTION
Just got my shelly HT plus today. mine reports the battery percentage as something like: {V=5.18, percent=64}
I suspect most users don't really want the voltage, personally, I want to be set an alert in RM to tell me when the battery is low - much easier if this driver just reports a single number for battery percentage