### PR TITLE
Fix - Presence flip/flop bug fix on Shelly Blu1 Buttons

### DIFF
--- a/ShellyDriverLibrary/ShellyUSA.ShellyUSA_Driver_Library.groovy
+++ b/ShellyDriverLibrary/ShellyUSA.ShellyUSA_Driver_Library.groovy
@@ -1123,19 +1123,18 @@ void setBatteryPercent(Integer percent) {
 
 @CompileStatic
 void checkPresence() {
-  List<Event> ev = thisDevice().events([max: 1])
-  if(ev?.size() > 0) {
-    Event lastEvent = ev[0]
-    logTrace("Last event: ${lastEvent.getUnixTime()}")
-    if(lastEvent != null) {
-      if(((unixTimeMillis() - lastEvent.getUnixTime()) / 1000) > (getDeviceSettings()?.presenceTimeout as Integer)) {
-        sendDeviceEvent([name: 'presence', value: 'not present', isStateChange: false])
-      } else {
-        sendDeviceEvent([name: 'presence', value: 'present', isStateChange: false])
-      }
+  List<Event> events = thisDevice().events([max: 50])
+  Event lastEvent = events?.find { it.name != 'presence' && it.name != 'lastUpdated' }
+  if(lastEvent != null) {
+    logTrace("Last real event: ${lastEvent.name} @ ${lastEvent.getUnixTime()}")
+    if(((unixTimeMillis() - lastEvent.getUnixTime()) / 1000) > (getDeviceSettings()?.presenceTimeout as Integer)) {
+      sendDeviceEvent([name: 'presence', value: 'not present', isStateChange: false])
+    } else {
+      sendDeviceEvent([name: 'presence', value: 'present', isStateChange: false])
     }
   }
 }
+
 
 @CompileStatic
 void setLevelAttribute(Integer level, ChildDeviceWrapper child = null) {

--- a/ShellyDriverLibrary/ShellyUSA.ShellyUSA_Driver_Library.groovy
+++ b/ShellyDriverLibrary/ShellyUSA.ShellyUSA_Driver_Library.groovy
@@ -1123,15 +1123,22 @@ void setBatteryPercent(Integer percent) {
 
 @CompileStatic
 void checkPresence() {
-  List<Event> events = thisDevice().events([max: 50])
+  Integer presenceTimeout = (getDeviceSettings()?.presenceTimeout as Integer)
+  // checkPresence is scheduled every 60 seconds, so scale the history window to
+  // cover at least the configured timeout plus a small buffer for scheduler drift.
+  Integer eventWindow = Math.max(50, (((int) Math.ceil((presenceTimeout ?: 300) / 60.0d))) + 5)
+
+  List<Event> events = thisDevice().events([max: eventWindow])
   Event lastEvent = events?.find { it.name != 'presence' && it.name != 'lastUpdated' }
   if(lastEvent != null) {
     logTrace("Last real event: ${lastEvent.name} @ ${lastEvent.getUnixTime()}")
-    if(((unixTimeMillis() - lastEvent.getUnixTime()) / 1000) > (getDeviceSettings()?.presenceTimeout as Integer)) {
+    if(((unixTimeMillis() - lastEvent.getUnixTime()) / 1000) > presenceTimeout) {
       sendDeviceEvent([name: 'presence', value: 'not present', isStateChange: false])
     } else {
       sendDeviceEvent([name: 'presence', value: 'present', isStateChange: false])
     }
+  } else {
+    logTrace("No real event found in last ${eventWindow} events while checking presence")
   }
 }
 


### PR DESCRIPTION
Beacons were flip flopping between present and not present every 60 seconds when beacons were out of range of the gateway (away state).  The cause was that it was still checking the last message event and picking that up as “present”

The query needs to ignore presence events (and ideally lastUpdated, which is also written synthetically) so it only considers events that reflect actual beacon data.