### PR TITLE
fix(linkedgo): preserve component type in virtualMap and own polling flow

### DIFF
--- a/Apps/ShellyDeviceManager.groovy
+++ b/Apps/ShellyDeviceManager.groovy
@@ -16570,17 +16570,11 @@ void componentRefresh(def childDevice) {
             syncCoverConfigForParentChildren(parentDni, ipAddress)
         } else {
             String refreshTypeName = childDevice.typeName ?: ''
-            // DALI Dimmer and Linkedgo virtual-component thermostats both consume the full
-            // deviceStatus map directly (they don't have a single componentType/componentId
-            // pairing — DALI maps lights dynamically; Linkedgo maps virtual instance IDs
-            // to roles via state.virtualMap built from Shelly.GetComponents).
-            if (refreshTypeName.contains('DALI Dimmer') ||
-                refreshTypeName.contains('Linkedgo ST1820') ||
-                refreshTypeName.contains('Linkedgo ST802')) {
-                if (refreshTypeName.contains('Linkedgo')) {
-                    logTrace("componentRefresh Linkedgo dispatch: typeName=${refreshTypeName}, status keys=${deviceStatus?.keySet()}")
-                    logTrace("componentRefresh Linkedgo full status=${groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(deviceStatus))}")
-                }
+            // DALI Dimmer consumes the full deviceStatus map directly because it maps
+            // lights dynamically and has no single componentType/componentId pairing.
+            // (Linkedgo thermostats also need the full map but own their own polling
+            // flow via componentLinkedgoFetchStatus → driver-side distributeStatus.)
+            if (refreshTypeName.contains('DALI Dimmer')) {
                 childDevice.distributeStatus(deviceStatus)
             } else {
                 // Single child refresh: only update this child
@@ -17198,16 +17192,20 @@ void componentUpdateGen1ThermostatSettings(def childDevice, Map settingsMap) {
 // postCommandSync (which itself is non-static).
 
 /**
- * Queries Shelly.GetComponents and returns a role->id map for all virtual
- * components owned by service:0. The driver caches the result in
- * state.virtualMap and re-fetches when stale (instance ID seen in status
- * not present in cached map).
+ * Queries Shelly.GetComponents and returns a role->"type:id" map for all virtual
+ * components owned by service:0. The driver caches the result in state.virtualMap
+ * and re-fetches when stale (component key seen in status not present in cached map).
+ *
+ * The full "type:id" key (e.g. "boolean:202", "number:202") is preserved in the
+ * value because Tuya-bridged devices reuse the same numeric instance id across
+ * boolean / number / enum component types — collapsing to id-only would conflate
+ * paired components like enable (boolean:202) and target_temperature (number:202).
  *
  * @param childDevice The Linkedgo child device
- * @return Map of role (String) -> instance ID (Integer); empty map on failure
+ * @return Map of role (String) -> component key (String, "type:id"); empty map on failure
  */
 Map componentLinkedgoGetComponents(def childDevice) {
-    Map<String, Integer> result = [:]
+    Map<String, String> result = [:]
     try {
         String ip = childDevice.getDataValue('ipAddress')
         if (!ip) {
@@ -17230,17 +17228,43 @@ Map componentLinkedgoGetComponents(def childDevice) {
             // Schema-flexible role lookup — LinkedGo firmware may surface 'role' under config, attrs, meta, or top-level
             String role = (comp.config?.role ?: comp.attrs?.role ?: comp.meta?.role ?: comp.role)?.toString()
             if (!key || !role) { return }
-            String[] parts = key.split(':')
-            if (parts.length != 2) { return }
-            try {
-                result[role] = parts[1] as Integer
-            } catch (NumberFormatException ignored) {}
+            if (key.split(':').length != 2) { return }
+            result[role] = key
         }
         logDebug("componentLinkedgoGetComponents: discovered ${result.size()} role mappings for ${childDevice.displayName}: ${result}")
     } catch (Exception e) {
         logError("componentLinkedgoGetComponents exception for ${childDevice.displayName}: ${e.message}")
     }
     return result
+}
+
+/**
+ * Linkedgo-specific status fetch. Returns the full Shelly.GetStatus result map
+ * to the calling driver, which then distributes it locally via distributeStatus().
+ *
+ * This bypasses componentRefresh()'s generic parent/child dispatch (which is
+ * designed for switch/cover/light multi-component devices) so the Linkedgo
+ * driver owns the full request → response → distribute flow. Crucially, every
+ * step then logs in device context, where users typically read driver logs —
+ * the parent dispatcher's logs live in app context and are easy to miss.
+ *
+ * @param childDevice The Linkedgo child device
+ * @return The full Shelly.GetStatus result map, or null on failure
+ */
+Map componentLinkedgoFetchStatus(def childDevice) {
+    try {
+        String ip = childDevice.getDataValue('ipAddress')
+        if (!ip) {
+            logError("componentLinkedgoFetchStatus: no IP for ${childDevice.displayName}")
+            return null
+        }
+        Map status = queryDeviceStatus(ip)
+        logTrace("componentLinkedgoFetchStatus: ${childDevice.displayName} returning ${status?.size() ?: 0} keys")
+        return status
+    } catch (Exception e) {
+        logError("componentLinkedgoFetchStatus exception for ${childDevice.displayName}: ${e.message}")
+        return null
+    }
 }
 
 /**

--- a/UniversalDrivers/ShellyLinkedgoST1820.groovy
+++ b/UniversalDrivers/ShellyLinkedgoST1820.groovy
@@ -77,7 +77,7 @@ void installed() {
   sendEvent(name: 'antiFreezeEnabled', value: 'false', descriptionText: 'Initialized')
   sendEvent(name: 'childLockEnabled', value: 'false', descriptionText: 'Initialized')
   sendEvent(name: 'lastUpdated', value: 'Never')
-  parent?.componentRefresh(device)
+  fetchAndDistribute()
   initialize()
 }
 
@@ -97,12 +97,32 @@ void initialize() {
 
 void refresh() {
   logDebug('refresh() called')
-  parent?.componentRefresh(device)
+  fetchAndDistribute()
 }
 
 void scheduledPoll() {
   logDebug('scheduledPoll() triggered')
-  parent?.componentRefresh(device)
+  fetchAndDistribute()
+}
+
+/**
+ * Owns the polling control flow: queries the device via the parent app's
+ * Linkedgo-specific fetch helper, logs the response shape in device context
+ * (where this driver's logs live), and dispatches to distributeStatus().
+ *
+ * This intentionally bypasses the parent's generic componentRefresh()
+ * dispatcher — that path is designed for switch/cover/light multi-component
+ * devices and obscures failures in app-context logs.
+ */
+private void fetchAndDistribute() {
+  Map status = parent?.componentLinkedgoFetchStatus(device) as Map
+  Integer keyCount = status?.size() ?: 0
+  logTrace("fetchAndDistribute: parent returned ${keyCount} status keys: ${status?.keySet()}")
+  if (!status) {
+    logWarn('fetchAndDistribute: parent returned null/empty status — device may be unreachable')
+    return
+  }
+  distributeStatus(status)
 }
 
 private void schedulePolling() {
@@ -133,12 +153,23 @@ private void schedulePolling() {
 // ╚══════════════════════════════════════════════════════════════╝
 
 /**
- * Ensures state.virtualMap (role -> instance ID) is populated by querying
+ * Ensures state.virtualMap (role -> "type:id" string) is populated by querying
  * Shelly.GetComponents via the parent app. Called lazily before any RPC
- * write that needs to look up an instance ID by role.
+ * write that needs to look up a component key by role.
+ *
+ * Caches written by older versions of this driver stored bare Integer ids; if
+ * such a legacy cache is detected it is cleared so the next fetch repopulates
+ * with the type-aware "type:id" format. Without this, paired Tuya components
+ * (e.g. boolean:202 enable + number:202 target_temperature) would clobber each
+ * other in the reverse lookup used by distributeStatus.
  */
 private void ensureVirtualMap() {
   Map vm = state.virtualMap as Map
+  if (vm && !vm.isEmpty() && vm.values().every { it instanceof Integer }) {
+    logDebug('ensureVirtualMap: legacy Integer cache detected, clearing for re-fetch in type:id format')
+    state.remove('virtualMap')
+    vm = null
+  }
   if (vm && !vm.isEmpty()) {
     logTrace("ensureVirtualMap: cache hit (${vm})")
     return
@@ -255,19 +286,27 @@ private void relayDeviceSettings() {
 }
 
 /**
- * Resolves the instance ID for a Boolean role from state.virtualMap and
- * delegates to the parent dispatcher. Logs a warning if the role isn't
- * in the cache — the next refresh will repopulate.
+ * Resolves the component key ("boolean:NNN") for a Boolean role from
+ * state.virtualMap, extracts the numeric instance id, and delegates to the
+ * parent dispatcher. Traces (rather than warns) if the role isn't in the
+ * cache — the next refresh will repopulate. Warns if the role resolves to
+ * a non-boolean component (a schema-flexibility safeguard).
  */
 private void setBooleanRole(String role, Boolean value) {
   ensureVirtualMap()
   Map vm = (state.virtualMap ?: [:]) as Map
-  Integer id = vm[role] as Integer
-  logTrace("setBooleanRole: role=${role}, value=${value}, resolved id=${id}, full virtualMap=${vm}")
-  if (id == null) {
-    logTrace("setBooleanRole: no instance ID for '${role}' — virtualMap not yet populated; refresh and retry")
+  String compKey = vm[role] as String
+  logTrace("setBooleanRole: role=${role}, value=${value}, resolved compKey=${compKey}, full virtualMap=${vm}")
+  if (!compKey) {
+    logTrace("setBooleanRole: no component key for '${role}' — virtualMap not yet populated; refresh and retry")
     return
   }
+  String[] parts = compKey.split(':')
+  if (parts.length != 2 || parts[0] != 'boolean') {
+    logWarn("setBooleanRole: '${role}' resolves to ${compKey}, expected a boolean component — skipping write")
+    return
+  }
+  Integer id = parts[1] as Integer
   parent?.componentLinkedgoSetBoolean(device, id, role, value)
   runIn(2, 'refresh', [overwrite: true])
 }
@@ -306,9 +345,9 @@ private BigDecimal readTempRangeMax() {
 // ╚══════════════════════════════════════════════════════════════╝
 
 /**
- * Receives the full Shelly.GetStatus result map from the parent app's
- * componentRefresh dispatcher. Resolves each virtual-instance entry
- * (boolean:N, number:N, enum:N) to a role via state.virtualMap and
+ * Receives the full Shelly.GetStatus result map (passed in by fetchAndDistribute()
+ * after componentLinkedgoFetchStatus returns). Resolves each virtual-instance
+ * entry (boolean:N, number:N, enum:N) to a role via state.virtualMap and
  * dispatches to the appropriate Hubitat attribute.
  *
  * @param status The complete Shelly.GetStatus result map
@@ -322,7 +361,7 @@ void distributeStatus(Map status) {
     ensureVirtualMap()
     ensureServiceConfig()
 
-    Map<String, Integer> virtualMap = (state.virtualMap ?: [:]) as Map<String, Integer>
+    Map<String, String> virtualMap = (state.virtualMap ?: [:]) as Map<String, String>
     logTrace("distributeStatus: virtualMap=${virtualMap}, serviceConfig keys=${(state.serviceConfig as Map)?.keySet()}")
     if (virtualMap.isEmpty()) {
       logTrace('distributeStatus: virtualMap empty — cannot route updates this cycle')
@@ -330,10 +369,12 @@ void distributeStatus(Map status) {
       return
     }
 
-    // Reverse map for instance-ID -> role lookup
+    // Reverse map for "type:id" -> role lookup. Keying by the full component
+    // key (not just the numeric id) is essential for Tuya-bridged devices that
+    // expose paired boolean/number components sharing a numeric id.
     Map<String, String> reverseMap = [:]
-    virtualMap.each { String role, Object id ->
-      reverseMap[id.toString()] = role
+    virtualMap.each { String role, Object compKey ->
+      reverseMap[compKey.toString()] = role
     }
     logTrace("distributeStatus: reverseMap=${reverseMap}")
 
@@ -346,15 +387,12 @@ void distributeStatus(Map status) {
       Map data = v as Map
       if (!key.startsWith('boolean:') && !key.startsWith('number:') && !key.startsWith('enum:')) { return }
 
-      String[] parts = key.split(':')
-      if (parts.length != 2) { return }
-      String idStr = parts[1]
-      String role = reverseMap[idStr]
-      logTrace("distributeStatus iter: key=${key}, idStr=${idStr}, resolved role=${role}, data=${data}")
+      String role = reverseMap[key]
+      logTrace("distributeStatus iter: key=${key}, resolved role=${role}, data=${data}")
       if (!role) {
         // Unknown virtual instance — likely stale virtualMap or a custom user-added component
         try {
-          Integer idNum = idStr as Integer
+          Integer idNum = key.split(':')[1] as Integer
           if (idNum >= 200) { staleDetected = true }
         } catch (NumberFormatException ignored) {}
         logTrace("distributeStatus: no role mapping for ${key}; skipping")

--- a/UniversalDrivers/ShellyLinkedgoST802.groovy
+++ b/UniversalDrivers/ShellyLinkedgoST802.groovy
@@ -93,7 +93,7 @@ void installed() {
   // Advertise supported modes/fan-modes for dashboards
   sendEvent(name: 'supportedThermostatModes', value: '["heat","cool","auto","off"]')
   sendEvent(name: 'supportedThermostatFanModes', value: '["auto","circulate","on"]')
-  parent?.componentRefresh(device)
+  fetchAndDistribute()
   initialize()
 }
 
@@ -112,12 +112,32 @@ void initialize() {
 
 void refresh() {
   logDebug('refresh() called')
-  parent?.componentRefresh(device)
+  fetchAndDistribute()
 }
 
 void scheduledPoll() {
   logDebug('scheduledPoll() triggered')
-  parent?.componentRefresh(device)
+  fetchAndDistribute()
+}
+
+/**
+ * Owns the polling control flow: queries the device via the parent app's
+ * Linkedgo-specific fetch helper, logs the response shape in device context
+ * (where this driver's logs live), and dispatches to distributeStatus().
+ *
+ * This intentionally bypasses the parent's generic componentRefresh()
+ * dispatcher — that path is designed for switch/cover/light multi-component
+ * devices and obscures failures in app-context logs.
+ */
+private void fetchAndDistribute() {
+  Map status = parent?.componentLinkedgoFetchStatus(device) as Map
+  Integer keyCount = status?.size() ?: 0
+  logTrace("fetchAndDistribute: parent returned ${keyCount} status keys: ${status?.keySet()}")
+  if (!status) {
+    logWarn('fetchAndDistribute: parent returned null/empty status — device may be unreachable')
+    return
+  }
+  distributeStatus(status)
 }
 
 private void schedulePolling() {
@@ -147,8 +167,22 @@ private void schedulePolling() {
 // ║  Virtual-Component Cache                                     ║
 // ╚══════════════════════════════════════════════════════════════╝
 
+/**
+ * Ensures state.virtualMap (role -> "type:id" string) is populated by querying
+ * Shelly.GetComponents via the parent app. Caches written by older versions
+ * of this driver stored bare Integer ids; if a legacy cache is detected it
+ * is cleared so the next fetch repopulates with the type-aware "type:id"
+ * format. Without this, paired Tuya components (e.g. boolean:202 enable +
+ * number:202 target_temperature) would clobber each other in the reverse
+ * lookup used by distributeStatus.
+ */
 private void ensureVirtualMap() {
   Map vm = state.virtualMap as Map
+  if (vm && !vm.isEmpty() && vm.values().every { it instanceof Integer }) {
+    logDebug('ensureVirtualMap: legacy Integer cache detected, clearing for re-fetch in type:id format')
+    state.remove('virtualMap')
+    vm = null
+  }
   if (vm && !vm.isEmpty()) {
     logTrace("ensureVirtualMap: cache hit (${vm})")
     return
@@ -349,12 +383,18 @@ private void relayDeviceSettings() {
 private void setBooleanRole(String role, Boolean value) {
   ensureVirtualMap()
   Map vm = (state.virtualMap ?: [:]) as Map
-  Integer id = vm[role] as Integer
-  logTrace("setBooleanRole: role=${role}, value=${value}, resolved id=${id}, full virtualMap=${vm}")
-  if (id == null) {
-    logTrace("setBooleanRole: no instance ID for '${role}' — virtualMap not yet populated; refresh and retry")
+  String compKey = vm[role] as String
+  logTrace("setBooleanRole: role=${role}, value=${value}, resolved compKey=${compKey}, full virtualMap=${vm}")
+  if (!compKey) {
+    logTrace("setBooleanRole: no component key for '${role}' — virtualMap not yet populated; refresh and retry")
     return
   }
+  String[] parts = compKey.split(':')
+  if (parts.length != 2 || parts[0] != 'boolean') {
+    logWarn("setBooleanRole: '${role}' resolves to ${compKey}, expected a boolean component — skipping write")
+    return
+  }
+  Integer id = parts[1] as Integer
   parent?.componentLinkedgoSetBoolean(device, id, role, value)
   runIn(2, 'refresh', [overwrite: true])
 }
@@ -394,7 +434,7 @@ void distributeStatus(Map status) {
     ensureVirtualMap()
     ensureServiceConfig()
 
-    Map<String, Integer> virtualMap = (state.virtualMap ?: [:]) as Map<String, Integer>
+    Map<String, String> virtualMap = (state.virtualMap ?: [:]) as Map<String, String>
     logTrace("distributeStatus: virtualMap=${virtualMap}, serviceConfig keys=${(state.serviceConfig as Map)?.keySet()}")
     if (virtualMap.isEmpty()) {
       logTrace('distributeStatus: virtualMap empty — cannot route updates this cycle')
@@ -402,9 +442,12 @@ void distributeStatus(Map status) {
       return
     }
 
+    // Reverse map for "type:id" -> role lookup. Keying by the full component
+    // key (not just the numeric id) is essential for Tuya-bridged devices that
+    // expose paired boolean/number components sharing a numeric id.
     Map<String, String> reverseMap = [:]
-    virtualMap.each { String role, Object id ->
-      reverseMap[id.toString()] = role
+    virtualMap.each { String role, Object compKey ->
+      reverseMap[compKey.toString()] = role
     }
     logTrace("distributeStatus: reverseMap=${reverseMap}")
 
@@ -417,14 +460,11 @@ void distributeStatus(Map status) {
       Map data = v as Map
       if (!key.startsWith('boolean:') && !key.startsWith('number:') && !key.startsWith('enum:')) { return }
 
-      String[] parts = key.split(':')
-      if (parts.length != 2) { return }
-      String idStr = parts[1]
-      String role = reverseMap[idStr]
-      logTrace("distributeStatus iter: key=${key}, idStr=${idStr}, resolved role=${role}, data=${data}")
+      String role = reverseMap[key]
+      logTrace("distributeStatus iter: key=${key}, resolved role=${role}, data=${data}")
       if (!role) {
         try {
-          Integer idNum = idStr as Integer
+          Integer idNum = key.split(':')[1] as Integer
           if (idNum >= 200) { staleDetected = true }
         } catch (NumberFormatException ignored) {}
         logTrace("distributeStatus: no role mapping for ${key}; skipping")


### PR DESCRIPTION
## Summary
- Preserves the full `"type:id"` component key in `state.virtualMap` so paired Tuya boolean/number components (e.g. `boolean:202` enable + `number:202` target_temperature) no longer collide in the reverse-lookup used by `distributeStatus`.
- Moves the polling control flow out of the parent app's generic `componentRefresh` dispatcher and into the Linkedgo drivers themselves via a new `componentLinkedgoFetchStatus` helper + driver-side `fetchAndDistribute` — failures now surface as a single warn line in the **device** log instead of vanishing into app context.
- Adds a legacy-cache migration in `ensureVirtualMap` so existing installs auto-upgrade their `state.virtualMap` from `Integer`-valued to `"type:id"`-valued without manual re-discovery.

## Why
The ST1820 driver had two distinct defects masking each other:

**Defect A — virtualMap collapsed paired components.** Tuya-bridged thermostats expose paired `boolean:N` + `number:N` components that share the same numeric `id`. `componentLinkedgoGetComponents` was storing `role -> Integer(id)`, discarding the type prefix. `distributeStatus` then built a reverseMap keyed by id-only — so for id `201` it ended up with only one of `current_temperature` / `child_lock`. Status updates either routed to the wrong handler or threw on incompatible casts (caught and swallowed by the outer try/catch). User logs showed this exactly: `[current_temperature:201, enable:202, current_humidity:200, target_temperature:202, anti_freeze:200, child_lock:201]` — six roles collapsed into three ids.

**Defect B — `distributeStatus` was never invoked at all.** Even with trace logging on, the user's log showed command-path traces (`setBooleanRole`, `setHeatingSetpoint`) but **zero** traces from inside `distributeStatus` (`distributeStatus_input`, `virtualMap=`, `reverseMap=`, per-iteration logs). The parent app's `componentRefresh` was exiting before reaching `childDevice.distributeStatus(deviceStatus)`, but the failure point — `queryDeviceStatus` returning null, an exception in the dispatcher, or a `typeName` mismatch — logged in *app* context, invisible to users reading the device log.

The structural fix solves both: the driver now owns the entire polling flow, every step logs in device context, and the Tuya pairing convention is correctly handled.

## Files changed
- `Apps/ShellyDeviceManager.groovy` — `componentLinkedgoGetComponents` stores `"type:id"`; new `componentLinkedgoFetchStatus` helper; dead Linkedgo branch removed from `componentRefresh`.
- `UniversalDrivers/ShellyLinkedgoST1820.groovy` and `UniversalDrivers/ShellyLinkedgoST802.groovy` — identical changes: legacy-cache migration in `ensureVirtualMap`, `setBooleanRole` parses `"boolean:NNN"`, `distributeStatus` reverseMap keyed by full `"type:id"`, new `fetchAndDistribute` replaces all `parent?.componentRefresh(device)` calls.

## Reviewer notes
- The Linkedgo branch in `componentRefresh` (lines 16572-16596 in the previous version) is intentionally removed — Linkedgo devices now bypass the generic parent/child dispatcher. The DALI Dimmer branch is preserved.
- The legacy-cache migration in `ensureVirtualMap` checks `vm.values().every { it instanceof Integer }`; this is a one-shot upgrade path. After the first read post-upgrade, the cache is in the new format and the check is a no-op.
- `setBooleanRole` now warns (rather than silently routing) if a role unexpectedly resolves to a non-boolean component — defensive against future schema drift.
- No changes to `componentLinkedgoSetNumber`, `componentLinkedgoSetEnum`, or `componentLinkedgoSetBoolean` signatures; commands continue to work as before.

## Test plan
- [ ] App + both drivers install/reload cleanly on Hubitat (no "unparseable driver" errors from the `Map<String, String>` typing change).
- [ ] On an ST1820: open the device page, **Save Preferences** to clear `state.virtualMap`, then **Refresh**. Confirm device-log trace shows: `fetchAndDistribute: parent returned N status keys: [boolean:200, boolean:201, boolean:202, number:200, number:201, number:202, service:0, …]` followed by per-iteration `distributeStatus iter:` lines and `Temperature:`, `Heating setpoint:`, `Thermostat on/off` messages.
- [ ] Confirm `temperature`, `humidity`, `heatingSetpoint`, `switch`, `thermostatMode`, `antiFreezeEnabled`, `childLockEnabled` all populate in the **Current States** panel.
- [ ] End-to-end: change setpoint and toggle on/off in Hubitat UI; within ~3 seconds the corresponding attributes should reflect device state (the existing `runIn(2, 'refresh')` post-write fires `fetchAndDistribute`).
- [ ] If hardware available: verify ST802 mirror behavior (heat/cool/auto modes, fan modes, target_humidity).
- [ ] Existing installs upgrade smoothly: legacy `Integer`-valued `state.virtualMap` should auto-clear on first read with `ensureVirtualMap: legacy Integer cache detected, clearing for re-fetch in type:id format` debug message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)