### PR TITLE
Add Gen4 Flood driver and Gen2+ Voltmeter (Add-On) support to legacy webhook driver suite

### DIFF
--- a/PackageManifests/ShellyWebhookDrivers/packageManifest.json
+++ b/PackageManifests/ShellyWebhookDrivers/packageManifest.json
@@ -218,6 +218,13 @@
       "required": false
     },
     {
+      "id": "5a138edc-b0f8-452d-89cd-b33bf9c6c2ba",
+      "name": "Shelly Flood Gen4",
+      "namespace": "ShellyUSA",
+      "location": "https://github.com/ShellyUSA/Hubitat-Drivers/releases/download/v2.16.2/ShellyFloodGen4-v2.16.2.groovy",
+      "required": false
+    },
+    {
       "id": "0f01c8d2-3cb7-4d99-828e-da2a44d6fa91",
       "name": "Shelly Gas",
       "namespace": "ShellyUSA",

--- a/ShellyDriverLibrary/ShellyUSA.ShellyUSA_Driver_Library.groovy
+++ b/ShellyDriverLibrary/ShellyUSA.ShellyUSA_Driver_Library.groovy
@@ -343,6 +343,8 @@ void getPreferencesFromShellyDevice() {
       Set<String> lights = shellyGetConfigResult.keySet().findAll{it.startsWith('light')}
       Set<String> rgbs = shellyGetConfigResult.keySet().findAll{it.startsWith('rgb:')}
       Set<String> rgbws = shellyGetConfigResult.keySet().findAll{it.startsWith('rgbw')}
+      Set<String> floods = shellyGetConfigResult.keySet().findAll{it.startsWith('flood')}
+      Set<String> voltmeters = shellyGetConfigResult.keySet().findAll{it.startsWith('voltmeter')}
 
       logDebug("Found Switches: ${switches}")
       logDebug("Found Inputs: ${inputs}")
@@ -355,6 +357,8 @@ void getPreferencesFromShellyDevice() {
       logDebug("Found Lights: ${lights}")
       logDebug("Found RGBs: ${rgbs}")
       logDebug("Found RGBWs: ${rgbws}")
+      logDebug("Found Floods: ${floods}")
+      logDebug("Found Voltmeters: ${voltmeters}")
 
       if(switches?.size() > 0) {
         logDebug('One or more switches found, running Switch.GetConfig for each...')
@@ -551,6 +555,30 @@ void getPreferencesFromShellyDevice() {
       } else {
         logDebug('No RGBWs found...')
       }
+
+      if(floods?.size() > 0) {
+        logDebug('One or more floods found...')
+        floods.each{ flood ->
+          Integer id = flood.tokenize(':')[1] as Integer
+          logDebug("Flood ID: ${id}")
+          setDeviceDataValue('floodId', "${id}")
+        }
+      } else {
+        logDebug('No floods found...')
+      }
+
+      if(voltmeters?.size() > 0) {
+        logDebug('One or more voltmeters found...')
+        if(hasNoChildrenNeeded() == false) {
+          voltmeters.each{ vm ->
+            Integer id = vm.tokenize(':')[1] as Integer
+            logDebug("Creating child device for voltmeter:${id}...")
+            ChildDeviceWrapper child = createChildVoltmeter(id)
+          }
+        }
+      } else {
+        logDebug('No voltmeters found...')
+      }
     } else {
       getPreferencesFromShellyDeviceGen1()
     }
@@ -745,8 +773,13 @@ void configure() {
     }
 
     if(isGen1Device() == true) {
-      try {setDeviceActionsGen1()}
-      catch(e) {logDebug("No device actions configured. Encountered error :${e}")}
+      Integer reportedGen = getIntegerDeviceDataValue('gen')
+      if(reportedGen != null && reportedGen > 1) {
+        logWarn("This driver only supports Gen1 devices, but this device reports gen=${reportedGen}. Skipping Gen1 action setup — switch to the matching Gen2+ driver (e.g. 'Shelly Flood Gen4 (Webhook)' for the Gen4 flood sensor) and run Configure again.")
+      } else {
+        try {setDeviceActionsGen1()}
+        catch(e) {logDebug("No device actions configured. Encountered error :${e}")}
+      }
     } else if(wsShouldBeConnected() == false) {
       try {setDeviceActionsGen2()}
       catch(e) {logDebug("No device actions configured. Encountered error :${e}")}
@@ -3745,6 +3778,35 @@ void processGen2JsonMessageBody(LinkedHashMap<String, Object> json, Integer id =
       }
       logTrace("Update: ${prettyJson(update)}")
     }
+
+    if(k.startsWith('flood')) {
+      LinkedHashMap update = (LinkedHashMap)v
+      id = update?.id as Integer
+      if(update?.alarm != null) {
+        Boolean alarm = update?.alarm as Boolean
+        if(alarm != null) { setFloodOn(alarm) }
+      }
+      List<String> errors = (List<String>)update?.errors
+      if(errors?.contains('cable_unplugged') == true) {
+        logWarn('Flood sensor reports sensing cable unplugged')
+      }
+    }
+
+    if(k.startsWith('voltmeter')) {
+      LinkedHashMap update = (LinkedHashMap)v
+      id = update?.id as Integer
+      if(update?.voltage != null && update?.voltage != '') {
+        BigDecimal voltage = update?.voltage as BigDecimal
+        if(voltage != null) { setVoltage(voltage, id) }
+      }
+    }
+
+    if(k.startsWith('devicepower')) {
+      LinkedHashMap update = (LinkedHashMap)v
+      LinkedHashMap battery = (LinkedHashMap)update?.battery
+      Integer percent = battery?.percent as Integer
+      if(percent != null) { setBatteryPercent(percent) }
+    }
   }
   setLastUpdated()
 }
@@ -4201,6 +4263,12 @@ void parseGen2Message(String raw) {
   else if(query[0] == 'smoke.alarm')      {setSmokeState('detected', query[1] as Integer)}
   else if(query[0] == 'smoke.alarm_off')  {setSmokeState('clear', query[1] as Integer)}
   else if(query[0] == 'smoke.alarm_test') {setSmokeState('tested', query[1] as Integer)}
+  else if(query[0] == 'flood.alarm')           {setFloodOn(true)}
+  else if(query[0] == 'flood.alarm_off')       {setFloodOn(false)}
+  else if(query[0] == 'flood.cable_unplugged') {logWarn('Flood sensor reports sensing cable unplugged')}
+  else if(query[0].startsWith('voltmeter.') && query[1] == 'voltage' && query.size() == 4) {
+    setVoltage(new BigDecimal(query[2]), id)
+  }
   else if(query[0].startsWith('light.o')) {
     String command = query[0]
     id = query[1] as Integer
@@ -4476,6 +4544,8 @@ void setDeviceActionsGen2() {
     Set<String> lights = shellyGetConfigResult.keySet().findAll{it.startsWith('light')}
     Set<String> rgbs = shellyGetConfigResult.keySet().findAll{it.startsWith('rgb:')}
     Set<String> rgbws = shellyGetConfigResult.keySet().findAll{it.startsWith('rgbw')}
+    Set<String> floods = shellyGetConfigResult.keySet().findAll{it.startsWith('flood')}
+    Set<String> voltmeters = shellyGetConfigResult.keySet().findAll{it.startsWith('voltmeter')}
 
     logDebug("Found Switches: ${switches}")
     logDebug("Found Inputs: ${inputs}")
@@ -4487,6 +4557,8 @@ void setDeviceActionsGen2() {
     logDebug("Found Lights: ${lights}")
     logDebug("Found RGBs: ${rgbs}")
     logDebug("Found RGBWs: ${rgbws}")
+    logDebug("Found Floods: ${floods}")
+    logDebug("Found Voltmeters: ${voltmeters}")
 
     // LinkedHashMap inputConfig = (LinkedHashMap)shellyGetConfigResult[inp]
     // String inputType = (inputConfig?.type as String).capitalize()
@@ -4498,6 +4570,7 @@ void setDeviceActionsGen2() {
       if(val != null && val.size() > 0) {
         attrs = ((LinkedHashMap)val).attrs as List<LinkedHashMap>
       }
+      if(attrs == null) { attrs = [] }
       logDebug("Processing type: ${type} with value: ${prettyJson(val)}")
 
 
@@ -4592,6 +4665,23 @@ void setDeviceActionsGen2() {
           logDebug("Processing webhook for rgbw:${cid}...")
           processWebhookCreateOrUpdate(name, cid, currentWebhooks, type, attrs)
         }
+      } else if(type.startsWith('flood')) {
+        floods.each{ flood ->
+          LinkedHashMap conf = (LinkedHashMap)shellyGetConfigResult[flood]
+          Integer cid = conf?.id as Integer
+          String name = "hubitat.${type}".toString()
+          logDebug("Processing webhook for flood:${cid}...")
+          processWebhookCreateOrUpdate(name, cid, currentWebhooks, type, attrs)
+        }
+      } else if(type == 'voltmeter.change') {
+        // voltmeter.measurement is deliberately skipped to conserve device webhook slots
+        voltmeters.each{ vm ->
+          LinkedHashMap conf = (LinkedHashMap)shellyGetConfigResult[vm]
+          Integer cid = conf?.id as Integer
+          String name = "hubitat.${type}".toString()
+          logDebug("Processing webhook for voltmeter:${cid}...")
+          processWebhookCreateOrUpdate(name, cid, currentWebhooks, type, attrs)
+        }
       }
     }
   }
@@ -4614,8 +4704,8 @@ void processWebhookCreateOrUpdate(String name, Integer cid, List<LinkedHashMap> 
           if(hook?.name == "${name}.${event}.${cid}".toString()) {currentWebhook = hook}
         }
         logDebug("Current Webhook: ${currentWebhook}")
-        if(event == 'tF') {
-          logTrace('Skipping webhook creating for F changes, no need to send both C and F to Hubitat')
+        if(event == 'tF' || event == 'xvoltage') {
+          logTrace("Skipping webhook creation for ${event}, not needed by Hubitat")
         } else {
           webhookCreateOrUpdate(type, event, cid, currentWebhook)
         }
@@ -5136,6 +5226,30 @@ ChildDeviceWrapper createChildVoltage(Integer id) {
       child = addShellyDevice(driverName, dni, [name: "${driverName}", label: "${label}"])
       child.updateDataValue('adcId',"${id}")
       child.updateDataValue('polling','true')
+      return child
+    }
+    catch (UnknownDeviceTypeException e) {logException("${driverName} driver not found")}
+  } else { return child }
+}
+
+/**
+ * Creates a child device for a Gen2+ Voltmeter component, e.g. an Add-On analog input configured as a voltmeter.
+ * Updates arrive via webhooks/websocket/status refresh, so no 'polling' data value is set.
+ *
+ * @param id The voltmeter component ID (Add-On peripherals use IDs 100+)
+ * @return The created (or already existing) child device
+ */
+@CompileStatic
+ChildDeviceWrapper createChildVoltmeter(Integer id) {
+  String driverName = "Shelly Polling Voltage Sensor Component"
+  String dni = "${getThisDeviceDNI()}-voltmeter${id}"
+  ChildDeviceWrapper child = getShellyDevice(dni)
+  if (child == null) {
+    String label = "${thisDevice().getLabel()} - Voltmeter ${id}"
+    logDebug("Child device does not exist, creating child device with DNI, Name, Label: ${dni}, ${driverName}, ${label}")
+    try {
+      child = addShellyDevice(driverName, dni, [name: "${driverName}", label: "${label}"])
+      child.updateDataValue('adcId',"${id}")
       return child
     }
     catch (UnknownDeviceTypeException e) {logException("${driverName} driver not found")}

--- a/WebhookWebsocket/ShellyFloodGen4.groovy
+++ b/WebhookWebsocket/ShellyFloodGen4.groovy
@@ -1,0 +1,15 @@
+/**
+ * Version: 2.16.2
+ */
+#include ShellyUSA.ShellyUSA_Driver_Library
+
+metadata {
+  definition (name: 'Shelly Flood Gen4 (Webhook)', namespace: 'ShellyUSA', author: 'Daniel Winks', singleThreaded: false, importUrl: '') {
+    capability 'Battery' //battery - NUMBER, unit:%
+    capability 'Configuration'
+    capability 'WaterSensor' //water - ENUM ["wet", "dry"]
+    attribute 'lastUpdated', 'string'
+  }
+}
+
+@Field static Boolean NOCHILDREN = true


### PR DESCRIPTION
## Summary

Fixes two forum-reported problems in the legacy webhook/websocket driver suite.

### 1. Shelly Flood Gen4 (S4SN-0071A) unusable
- The only flood driver, `Shelly Flood (Webhook)`, is Gen1-only (`GEN1 = true`), so `configure()` called the Gen1-only `GET /settings/actions` endpoint on the Gen4 device → the reported `404 / "No device actions configured"` error.
- The library had **zero Gen2+ flood support**: `flood:N` components were never enumerated, no flood webhooks were created, and incoming `flood.*` events were not parsed.

**Changes:**
- New driver `WebhookWebsocket/ShellyFloodGen4.groovy` — `Shelly Flood Gen4 (Webhook)`: Battery, Configuration, WaterSensor, `NOCHILDREN`. Intentionally **no** `Initialize` capability (always-sleeping battery device — unreachable at hub boot), deviating from the Plus Smoke/H&T siblings on purpose.
- Library: `flood:N` enumeration (`floodId` data value), webhook creation for `flood.alarm` / `flood.alarm_off` / `flood.cable_unplugged`, webhook parsing → `water` wet/dry events via existing `setFloodOn()`, and `flood:N` status-body parsing for refresh-while-awake.
- Wrong-driver guard: when a Gen1 driver is used on a device that reports `gen > 1`, `configure()` now logs a clear warning naming the correct driver instead of surfacing a cryptic 404.
- HPM manifest entry for the new driver (new UUID; CI re-points version URLs at release).

### 2. Shelly i4 Gen3 + Plus Add-On: analog input as Voltmeter ignored
DS18B20 temperature peripherals worked; `voltmeter:100` was invisible to the driver.

**Changes:**
- Library: `voltmeter:N` enumeration → new `createChildVoltmeter()` creating a `Shelly Polling Voltage Sensor Component` child (DNI `-voltmeter<N>`, routed by `adcId` data value, **no** `polling` data value so no Gen1-style scheduled polling).
- Webhook creation for `voltmeter.change` (`voltmeter.measurement` and the `xvoltage` attr are deliberately skipped to conserve device webhook slots).
- Incoming webhook parsing (`/voltmeter.change/voltage/<val>/<cid>`) and `voltmeter:N` NotifyStatus/GetStatus body parsing — the latter is the load-bearing path since the i4 runs with `WS = true`.

### Bonus
- `devicepower:N` battery percent now parsed from full status bodies (battery updates on refresh-while-awake for sleepers).
- Defensive `attrs == null` guard in `setDeviceActionsGen2()` (avoids NPE if `Webhook.ListSupported` returns a type without `attrs`).

**No version bumps** — `release-shelly-drivers.yml` / `update-package-manifests.yml` manage `Version:` headers and manifest URLs at release time.

## Upgrade note (release notes)
Existing i4/Add-On installs must press **Initialize** (or re-save the IP in preferences) once after updating to discover the voltmeter child.

## Hardware test checklist

### Shelly Flood Gen4 (S4SN-0071A) — keep device awake (button press / web UI open) during setup
- [ ] Assign `Shelly Flood Gen4 (Webhook)` driver, set IP, Save Preferences → log shows `Found Floods: [flood:0]`, **no** `/settings/actions` 404
- [ ] `http://<ip>/rpc/Webhook.List` shows `hubitat.flood.alarm.0`, `hubitat.flood.alarm_off.0`, `hubitat.flood.cable_unplugged.0`; no duplicates after a second Configure
- [ ] Wet probes → `water: wet`; dry → `water: dry`; `lastUpdated` changes; `battery` populates shortly after an event
- [ ] While awake: Configure/refresh → status parse sets `water` from `flood:0.alarm` without errors
- [ ] Check `Shelly.GetConfig` for a `temperature:0` component → if present, file follow-up to add `TemperatureMeasurement` to the driver
- [ ] Wrong-driver guard: Gen4 unit on the Gen1 `Shelly Flood (Webhook)` driver + Configure → single clear logWarn naming the Gen4 driver, no 404 noise
- [ ] Regression: real Gen1 Flood (SHWT-1) on the Gen1 driver still configures actions
- [ ] Hub reboot → no error spam from the new flood device

### Shelly i4 Gen3 + Plus Add-On (voltmeter + DS18B20s)
- [ ] Press Initialize (or re-save IP) → `Found Voltmeters: [voltmeter:100]`, child `Shelly Polling Voltage Sensor Component` with DNI `<dni>-voltmeter100`, data `adcId=100`, **no** `polling` data value, no new scheduled refresh job
- [ ] Websocket mode (BLE gateway enabled): vary analog input → child `voltage` updates via NotifyStatus
- [ ] Webhook mode (ws not connected): Configure → `Webhook.List` shows exactly one voltmeter hook (`hubitat.voltmeter.change.voltage.100`; no xvoltage / no voltmeter.measurement); total hook count within device limit; voltage change past `report_thr` → child updates
- [ ] Child device Refresh command → voltage updates (Shelly.GetStatus path through parent)
- [ ] Regression: DS18B20 temperature children still update (webhook + refresh); i4 button events unaffected
- [ ] Regression: Gen1 device with ADC polling child (e.g. Shelly Uni) still polls voltage (`createChildVoltage` path untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)